### PR TITLE
feat: add proxy api to server

### DIFF
--- a/hg/api.py
+++ b/hg/api.py
@@ -11,12 +11,13 @@ import hg.utils as utils
 ## Mixins
 
 # Can't figure out a good way to type these classes.
-# We ignoring the errors in the parameter signature 
-# mean we can get good type information within the 
+# We ignoring the errors in the parameter signature
+# mean we can get good type information within the
 # function and return types are inferred for end users.
 
+
 class _PropertiesMixin:
-    def properties(self: utils.ModelT, inplace: bool = False, **fields) -> utils.ModelT: # type: ignore
+    def properties(self: utils.ModelT, inplace: bool = False, **fields) -> utils.ModelT:  # type: ignore
         model = self if inplace else utils.copy_unique(self)
         for k, v in fields.items():
             setattr(model, k, v)
@@ -24,7 +25,7 @@ class _PropertiesMixin:
 
 
 class _OptionsMixin:
-    def opts(self: "TrackT", inplace: bool = False, **options) -> "TrackT": # type: ignore
+    def opts(self: "TrackT", inplace: bool = False, **options) -> "TrackT":  # type: ignore
 
         track = self if inplace else utils.copy_unique(self)
         if track.options is None:

--- a/hg/fuse/__init__.py
+++ b/hg/fuse/__init__.py
@@ -17,7 +17,12 @@ class FuseProcess:
         self._tmp_dir: Optional[pathlib.Path] = None
 
     def start(self, tmp_dir: Union[str, pathlib.Path]):
-        from .httpfs import run
+        try:
+            from ._httpfs import run
+        except ImportError as e:
+            raise ImportError(
+                'Install "fusepy" and "simple-httpfs" to enable FUSE.'
+            ) from e
 
         # no need to restart
         tmp_dir = pathlib.Path(tmp_dir).absolute()

--- a/hg/server/__init__.py
+++ b/hg/server/__init__.py
@@ -26,6 +26,12 @@ class HgServer:
     def enable_proxy(self, urlprefix: str = ".."):
         if not self._provider:
             raise RuntimeError("Server not started.")
+        try:
+            import jupyter_server_proxy
+        except ImportError as e:
+            raise ImportError(
+                'Install "jupyter-server-proxy" to enable server proxying.'
+            ) from e
         self._provider.urlprefix = urlprefix
 
     def disable_proxy(self):

--- a/hg/server/__init__.py
+++ b/hg/server/__init__.py
@@ -23,6 +23,16 @@ class HgServer:
             self._provider.stop()
         self._resources = {}
 
+    def enable_proxy(self, urlprefix: str = ".."):
+        if not self._provider:
+            raise RuntimeError("Server not started.")
+        self._provider.urlprefix = urlprefix
+
+    def disable_proxy(self):
+        if not self._provider:
+            raise RuntimeError("Server not started.")
+        self._provider.urlprefix = None
+
     def add(
         self,
         tileset: LocalTileset,

--- a/hg/server/_provider.py
+++ b/hg/server/_provider.py
@@ -132,7 +132,7 @@ class TilesetProvider(BackgroundServer):
             urlprefix = os.environ.get("JUPYTERHUB_SERVICE_PREFIX")
 
         if urlprefix is not None:
-            urlprefix = urlprefix.rstrip('/')
+            urlprefix = urlprefix.rstrip("/")
             return f"{urlprefix}/proxy/{self.port}"
 
         return f"http://localhost:{self.port}"

--- a/hg/server/_provider.py
+++ b/hg/server/_provider.py
@@ -1,4 +1,5 @@
 import itertools
+import os
 import weakref
 from dataclasses import dataclass
 from typing import List, MutableMapping, Optional
@@ -10,20 +11,10 @@ import starlette.responses
 import starlette.routing
 
 from hg.api import track
-from hg.utils import TrackType
 from hg.tilesets import LocalTileset
+from hg.utils import TrackType, _datatype_default_track
 
 from ._background_server import BackgroundServer
-
-_datatype_default_track = {
-    "2d-rectangle-domains": "2d-rectangle-domains",
-    "bedlike": "bedlike",
-    "chromsizes": "horizontal-chromosome-labels",
-    "gene-annotations": "horizontal-gene-annotations",
-    "matrix": "heatmap",
-    "vector": "horizontal-bar",
-    "multivec": "horizontal-multivec",
-}
 
 
 @dataclass(frozen=True)
@@ -35,15 +26,15 @@ class TilesetResource:
     def server(self) -> str:
         return f"{self.provider.url}/api/v1/"
 
-    def track(self, type: Optional[TrackType] = None, **kwargs):
+    def track(self, type_: Optional[TrackType] = None, **kwargs):
         # use default track based on datatype if available
-        if type is None:
+        if type_ is None:
             if self.tileset.datatype is None:
                 raise ValueError("No default track for tileset")
             else:
-                type = _datatype_default_track[self.tileset.datatype]  # type: ignore
+                type_ = _datatype_default_track[self.tileset.datatype]  # type: ignore
         return track(
-            type_=type,  # type: ignore
+            type_=type_,  # type: ignore
             server=self.server,
             tilesetUid=self.tileset.uid,
             **kwargs,
@@ -109,6 +100,7 @@ def hello(_):
 
 class TilesetProvider(BackgroundServer):
     _tilesets: MutableMapping[str, LocalTileset]
+    urlprefix: Optional[str] = None
 
     def __init__(self, allowed_origins: Optional[List[str]] = None):
         self._tilesets = weakref.WeakValueDictionary()
@@ -133,6 +125,16 @@ class TilesetProvider(BackgroundServer):
 
     @property
     def url(self) -> str:
+        urlprefix = self.urlprefix
+
+        # https://github.com/yuvipanda/altair_data_server/blob/4d6ffcb19f864218c8d825ff2c95a1c8180585d0/altair_data_server/_altair_server.py#L73-L93
+        if urlprefix is None:
+            urlprefix = os.environ.get("JUPYTERHUB_SERVICE_PREFIX")
+
+        if urlprefix is not None:
+            urlprefix = urlprefix.rstrip('/')
+            return f"{urlprefix}/proxy/{self.port}"
+
         return f"http://localhost:{self.port}"
 
     def create(self, tileset: LocalTileset) -> TilesetResource:

--- a/hg/utils.py
+++ b/hg/utils.py
@@ -40,8 +40,20 @@ _track_default_position: Dict[str, TrackPosition] = {
     "viewport-projection-horizontal": "top",
 }
 
+_datatype_default_track = {
+    "2d-rectangle-domains": "2d-rectangle-domains",
+    "bedlike": "bedlike",
+    "chromsizes": "horizontal-chromosome-labels",
+    "gene-annotations": "horizontal-gene-annotations",
+    "matrix": "heatmap",
+    "vector": "horizontal-bar",
+    "multivec": "horizontal-multivec",
+}
+
+
 def uid():
     return str(slugid.nice())
+
 
 def get_default_track_position(track_type: str) -> Optional[TrackPosition]:
     return _track_default_position.get(track_type, None)
@@ -59,4 +71,3 @@ def copy_unique(model: ModelT) -> ModelT:
     if hasattr(copy, "uid"):
         setattr(copy, "uid", uid())
     return copy
-

--- a/hg/utils.py
+++ b/hg/utils.py
@@ -1,12 +1,9 @@
-from typing import Union, Dict, TypeVar, Optional, List
-
-from typing_extensions import Literal
-
-from pydantic import BaseModel
-import slugid
+from typing import Dict, List, Optional, TypeVar, Union
 
 import higlass_schema as hgs
-
+import slugid
+from pydantic import BaseModel
+from typing_extensions import Literal
 
 T = TypeVar("T")
 ModelT = TypeVar("ModelT", bound=BaseModel)


### PR DESCRIPTION
Fixes #10 

Allows Jupyter clients to proxy requests to underlying background server if necessary via [`jupyter-server-proxy`](https://github.com/jupyterhub/jupyter-server-proxy) routes. This is necessary to allow remote jupyter kernels (without requiring the remote server to expose additional ports). 

### Usage

```python
import hg

bw = hg.tilesets.bigwig('./data.bigwig')
ts = hg.server.add(bw)

print(ts.server) # "http://localhost:12345/api/v1"

hg.server.enable_proxy("../..") # provide relative prefix to "root" of notebook

print(ts.server) # "../../proxy/12345/api/v1"

# HiGlass client will now make requests relative to the location of the webpage

hg.server.disable_proxy() # reset

print(ts.server) # "http://localhost:12345/api/v1"
```

> Note: this is only necessary for remote self-hosted Jupyter notebooks (e.g. SSH). Local notebooks, Google Colab, and I believe MyBinder/JupyterHub instances should "just work"

@nvictus