### PR TITLE
feat: add `View.project` API

### DIFF
--- a/hg/api.py
+++ b/hg/api.py
@@ -121,28 +121,27 @@ class View(hgs.View[TrackT], _PropertiesMixin, Generic[TrackT]):
     def project(
         self,
         from_: "View",
-        to: Literal["center", "top", "bottom", "left", "right"] = "center",
+        position: Literal["center", "top", "bottom", "left", "right"] = "center",
         inplace: bool = False,
         **kwargs,
     ):
         view = self if inplace else utils.copy_unique(self)
 
         # projection track type from position
-        if to == "center":
+        if position == "center":
             track_type = "viewport-projection-center"
-        elif to == "top" or to == "bottom":
+        elif position == "top" or position == "bottom":
             track_type = "viewport-projection-horizontal"
-        elif to == "left" or to == "right":
+        elif position == "left" or position == "right":
             track_type = "viewport-projection-vertical"
         else:
             raise ValueError("Not possible")
 
-
-        if getattr(view.tracks, to) is None:
-            setattr(view.tracks, to, [])
+        if getattr(view.tracks, position) is None:
+            setattr(view.tracks, position, [])
 
         trk = track(type_=track_type, fromViewUid=from_.uid, **kwargs)
-        getattr(view.tracks, to).append(trk)
+        getattr(view.tracks, position).append(trk)
 
         return view
 

--- a/hg/api.py
+++ b/hg/api.py
@@ -1,5 +1,5 @@
-from collections import defaultdict
 import functools
+from collections import defaultdict
 from typing import ClassVar, Generic, List, Optional, Tuple, TypeVar, Union, overload
 
 import higlass_schema as hgs
@@ -117,6 +117,34 @@ class View(hgs.View[TrackT], _PropertiesMixin, Generic[TrackT]):
 
     def widget(self, **kwargs):
         return self.viewconf().widget(**kwargs)
+
+    def project(
+        self,
+        from_: "View",
+        to: Literal["center", "top", "bottom", "left", "right"] = "center",
+        inplace: bool = False,
+        **kwargs,
+    ):
+        view = self if inplace else utils.copy_unique(self)
+
+        # projection track type from position
+        if to == "center":
+            track_type = "viewport-projection-center"
+        elif to == "top" or to == "bottom":
+            track_type = "viewport-projection-horizontal"
+        elif to == "left" or to == "right":
+            track_type = "viewport-projection-vertical"
+        else:
+            raise ValueError("Not possible")
+
+
+        if getattr(view.tracks, to) is None:
+            setattr(view.tracks, to, [])
+
+        trk = track(type_=track_type, fromViewUid=from_.uid, **kwargs)
+        getattr(view.tracks, to).append(trk)
+
+        return view
 
 
 ViewT = TypeVar("ViewT", bound=View)
@@ -389,29 +417,6 @@ def divide(t1: T, t2: T, **kwargs) -> T:
     for key, val in kwargs.items():
         setattr(copy, key, val)
     return copy
-
-
-def project(
-    position: Literal["center", "top", "bottom", "left", "right"],
-    view: Optional[View] = None,
-    **kwargs,
-):
-    if view is None:
-        fromViewUid = None
-    else:
-        assert isinstance(view.uid, str)
-        fromViewUid = view.uid
-
-    if position == "center":
-        track_type = "viewport-projection-center"
-    elif position == "top" or position == "bottom":
-        track_type = "viewport-projection-horizontal"
-    elif position == "left" or position == "right":
-        track_type = "viewport-projection-vertical"
-    else:
-        raise ValueError("Not possible")
-
-    return track(type_=track_type, fromViewUid=fromViewUid, **kwargs)
 
 
 @overload

--- a/hg/api.py
+++ b/hg/api.py
@@ -120,30 +120,30 @@ class View(hgs.View[TrackT], _PropertiesMixin, Generic[TrackT]):
 
     def project(
         self,
-        from_: "View",
-        position: Literal["center", "top", "bottom", "left", "right"] = "center",
+        view: "View",
+        on: Literal["center", "top", "bottom", "left", "right"] = "center",
         inplace: bool = False,
         **kwargs,
     ):
-        view = self if inplace else utils.copy_unique(self)
+        new_view = self if inplace else utils.copy_unique(self)
 
         # projection track type from position
-        if position == "center":
+        if on == "center":
             track_type = "viewport-projection-center"
-        elif position == "top" or position == "bottom":
+        elif on == "top" or on == "bottom":
             track_type = "viewport-projection-horizontal"
-        elif position == "left" or position == "right":
+        elif on == "left" or on == "right":
             track_type = "viewport-projection-vertical"
         else:
             raise ValueError("Not possible")
 
-        if getattr(view.tracks, position) is None:
-            setattr(view.tracks, position, [])
+        if getattr(new_view.tracks, on) is None:
+            setattr(new_view.tracks, on, [])
 
-        trk = track(type_=track_type, fromViewUid=from_.uid, **kwargs)
-        getattr(view.tracks, position).append(trk)
+        trk = track(type_=track_type, fromViewUid=view.uid, **kwargs)
+        getattr(new_view.tracks, on).append(trk)
 
-        return view
+        return new_view
 
 
 ViewT = TypeVar("ViewT", bound=View)

--- a/hg/tilesets.py
+++ b/hg/tilesets.py
@@ -43,7 +43,6 @@ class RemoteTileset:
         return t
 
 
-
 def remote(uid: str, server: str = "https://higlass.io/api/v1", **kwargs):
     return RemoteTileset(uid, server, **kwargs)
 

--- a/notebooks/View_Projection.ipynb
+++ b/notebooks/View_Projection.ipynb
@@ -1,0 +1,69 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d07e8df0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "# Install if in Google colab notebook\n",
+    "if 'google.colab' in sys.modules:\n",
+    "    os.system('python -m pip install --upgrade --force-reinstall git+https://github.com/manzt/hg')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "131051a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hg\n",
+    "\n",
+    "ts = hg.remote(\n",
+    "    uid=\"CQMd6V_cRw6iCI_-Unl3PQ\",\n",
+    "    server=\"https://higlass.io/api/v1/\",\n",
+    "    name=\"Rao et al. (2014) GM12878 MboI (allreps) 1kb\",\n",
+    ")\n",
+    "\n",
+    "v1 = hg.view(ts.track(\"heatmap\"), width=3)\n",
+    "v2 = hg.view(ts.track(\"heatmap\"), width=9).project(v1, to=\"center\")\n",
+    "\n",
+    "v1 | v2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca80e07e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/View_Projection.ipynb
+++ b/notebooks/View_Projection.ipynb
@@ -31,7 +31,7 @@
     ")\n",
     "\n",
     "v1 = hg.view(ts.track(\"heatmap\"), width=3)\n",
-    "v2 = hg.view(ts.track(\"heatmap\"), width=9).project(v1, position=\"center\")\n",
+    "v2 = hg.view(ts.track(\"heatmap\"), width=9).project(v1, on=\"center\")\n",
     "\n",
     "v1 | v2"
    ]

--- a/notebooks/View_Projection.ipynb
+++ b/notebooks/View_Projection.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d07e8df0",
+   "id": "d1373f88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,7 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "131051a8",
+   "id": "8ae5be58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,7 +31,7 @@
     ")\n",
     "\n",
     "v1 = hg.view(ts.track(\"heatmap\"), width=3)\n",
-    "v2 = hg.view(ts.track(\"heatmap\"), width=9).project(v1, to=\"center\")\n",
+    "v2 = hg.view(ts.track(\"heatmap\"), width=9).project(v1, position=\"center\")\n",
     "\n",
     "v1 | v2"
    ]
@@ -39,7 +39,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca80e07e",
+   "id": "d4d3c71e",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Replaces `hg.project` (an explicit API for creating tracks) with `View.project` which **creates** and **adds** the projection track to the current View. Usage:

```python
import hg

v1 = hg.view(..., width=3)
v2 = hg.view(..., width=9).project(v1, on="center")

v1 | v2
```

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/24403730/158864532-77223ca8-b77f-422f-8029-dd2963c0946d.png">
