### PR TITLE
feat(server): impl `api/v1/chrom-sizes` route

### DIFF
--- a/hg/server/__init__.py
+++ b/hg/server/__init__.py
@@ -91,7 +91,7 @@ class HgServer:
         yield "tilesets", self._tilesets
         try:
             port = self.port
-        except:
+        except RuntimeError:
             port = None
         yield "port", port
 


### PR DESCRIPTION
Automatically implements chromsizes fallback route for a Tileset. Uses the `tileset_info` result from `clodius` to lookup chromsizes. Enables `*-chromosome-labels` tracks to be used for a given tileset:

```python
import hg

ts = hg.cooler('./test.mcool')

hg.view(
  ts.track('horizontal-chromosome-labels'), # data-source is api/v1/chrom-sizes/?id={ts.uid}
  ts.track('heatmap') # data-source is api/v1/tileset_info/?d={ts.uid}
)
```